### PR TITLE
Classes, decorators, annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,21 +20,21 @@ jobs:
       VIRTUAL_ENV: /tmp/virtualenv
 
     steps:
-      - name: Clone branch
-        # Cloning the branch directly is a few seconds faster than using actions/checkout@v2,
-        # since the latter is way fancier than we actually need.
+      - name: Check out test branch.
+        # Fetching and checking out the branch directly is a few seconds faster than using
+        # actions/checkout@v2, since the latter is way fancier than we actually need.
         #   gc.auto 0
         #     GC is slow, so disable it.
         #   fetch --no-tags
         #     There might be a large number of tags. Ignore them.
         run: |
-          # Clone branch.
+          # Check out test branch.
           set -v
           git init ${{ github.workspace }}
           cd ${{ github.workspace }}
           git remote add origin https://github.com/${{ github.repository }}
           git config --local gc.auto 0
-          git fetch --no-tags --depth=1 origin main
+          git fetch --no-tags --depth=1 origin main:main +${{ github.sha }}:test
           git checkout main
 
           # Set modified time of each file to the latest commit time so pytest caching works.
@@ -42,8 +42,7 @@ jobs:
           git log --pretty=%at --name-status --reverse |
             perl -ane '($x,$f)=@F;next if !$x;$t=$x,next if !defined($f)||$s{$f};$s{$f}=utime($t,$t,$f),next if $x=~/[AM]/;'
 
-          # Finally, checkout the commit we want to test so that any files have their mtime updated.
-          git fetch --no-tags --depth=1 origin +${{ github.sha }}:test
+          # Finally, checkout the commit we want to test so that any modified files have their mtime updated.
           git checkout test
 
       - name: Cache virtualenv
@@ -91,7 +90,7 @@ jobs:
         # (rather than with "use:") to avoid downloading it at all if we won't need it.
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          # Install Python
+          # Install Python (skip if cache was restored).
           if [ ! -d "$VIRTUAL_ENV" ]; then  # Skip if cache restored, even an order cache.
             set -v
             git -c advice.detachedHead=0 clone https://github.com/actions/setup-python -b v2 --depth 1 /tmp/setup-python
@@ -104,7 +103,7 @@ jobs:
         # this section to run.
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          # Set up virtualenv
+          # Set up virtualenv (skip if cache was restored).
           if [ ! -d "$VIRTUAL_ENV" ]; then  # Skip if cache restored, even an order cache.
             python -m venv $VIRTUAL_ENV
             source $VIRTUAL_ENV/bin/activate
@@ -114,5 +113,6 @@ jobs:
 
       - name: Test with pytest
         run: |
+          # Test with pytest.
           source $VIRTUAL_ENV/bin/activate
           python -m pytest --pylint --flake8 -o cache_dir=/tmp/pytest_cache

--- a/src/compiler/syntax/class_.py
+++ b/src/compiler/syntax/class_.py
@@ -6,6 +6,8 @@ import attr
 
 from . import namespace, function, variable
 
+# pylint: disable=fixme
+
 
 @attr.s(frozen=True, slots=True)
 class Class(namespace.Declarable):

--- a/src/compiler/syntax/class_.py
+++ b/src/compiler/syntax/class_.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import typing
+
+import attr
+
+from . import namespace, function, variable
+
+
+@attr.s(frozen=True, slots=True)
+class Class(namespace.Declarable):
+    """A Class declaration and definition.
+    """
+    bases: typing.Sequence[Class] = attr.ib(converter=tuple, default=(), repr=False)
+    members: typing.Sequence[typing.Union[function.Function, variable.Variable]] = attr.ib(
+        converter=tuple,
+        default=(),
+        repr=False,
+    )
+    # TODO: figure out how scopes will work for classes
+
+
+@attr.s(frozen=True, slots=True)
+class StaticMethod(function.Function.Decorator):
+    """Decorator to denote a method as static.
+
+    Static methods are not bound to an instance and do not receive
+    the instance as their first argument.
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class ClassMethod(function.Function.Decorator):
+    """Decorator to denote a method as a class method.
+
+    Class methods are not bound to an instance; instead, they are bound
+    to the class and receive the class as their first argument. In particular,
+    when a class method is called on a subclass or instance of a subclass, it
+    receives the subclass as its first argument.
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class Getter(function.Function.Decorator):
+    """Decorator to denote a method as a "getter" for an attribute of the same name.
+
+    Accessing the attribute on an instance causes the decorated method to be called.
+    The return value of the decorated method is returned as the attribute value.
+
+    This decorator has no effect on class attribute access unless also used in
+    conjunction with ClassMethod or StaticMethod. When used with ClassMethod, the
+    method is called with the class as its only argument. When used with StaticMethod,
+    the method is called with no arguments.
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class Setter(function.Function.Decorator):
+    """Decorator to denote a method as a "setter" for an attribute of the same name.
+
+    Assigning to the attribute on an instance causes the decorated method to be called
+    with the assigned value as its second argument.
+
+    This decorator has no effect on class attribute access unless also used in
+    conjunction with ClassMethod or StaticMethod. When used with ClassMethod, the
+    method is called with the class as its first argument and the assigned value as
+    its second argument. When used with StaticMethod, the method is called with the
+    assigned value as its only argument.
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class Private(function.Function.Decorator, variable.Variable.Annotation):
+    """Decorator/Annotation to denote a method or attribute as "private".
+
+    Private methods/attributes may only be accessed from methods of the same class.
+    Subclasses cannot override private methods/attributes; defining a method/attribute
+    of the same name in a subclass is allowed, but does not override the implementation
+    defined by the parent class (when accessed from the parent class).
+
+    When a private method/attribute shares the same name as a public method/attribute,
+    the private method/attribute takes precedence when accessed from methods of the
+    same class; when accessed externally, the public method/attribute is used (since
+    the private method/attribute is not visible externally).
+
+    TODO: Design a test framework API which provides access to private methods/attributes.
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class Protected(function.Function.Decorator, variable.Variable.Annotation):
+    """Decorator/Annotation to denote a method or attribute as "protected".
+
+    Protected methods/attributes may only be accessed from methods of the same class,
+    or methods of any of its subclasses. Subclasses may override protected methods/attributes
+    with their own implementation.
+
+    When a protected method/attribute shares the same name as a public method/attribute,
+    the protected method/attribute takes precedence when accessed from methods of the same
+    class or methods of any of its subclasses; when accessed externally, the public method/
+    attribute is used (since the protected method/attribute is not visible externally).
+
+    TODO: Design a test framework API which provides access to protected methods/attributes.
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class Constructor(function.Function.Decorator, variable.Variable.Annotation):
+    """Decorator/Annotation to denote a method or attribute as part of the instance constructor.
+
+    Constructor attributes are appended as position_keyword arguments of the same name to the instance
+    constructor in the order in which they were declared.
+
+    Constructor methods have their arguments appended to the instance constructor. The instance
+    constructor calls these methods in the order in which they were declared, passing through matching
+    arguments. Constructor methods which share a name with an attribute are interpreted as factories
+    (or converters) for that attribute; that is, their return value is assigned to the attribute.
+    Otherwise, constructors cannot return anything. TODO: validation
+
+    Constructor methods cannot be asynchronous. TODO: validation
+    Constructor methods may omit the method name.
+
+    TODO: Figure out how to build the instance constructor (repeated argument names, etc).
+    """
+
+
+@attr.s(frozen=True, slots=True)
+class Destructor(function.Function.Decorator):
+    """Decorator to denote a method as part of the instance destructor.
+
+    Destructor methods are executed in the order in which they were declared.
+    Destructor methods may omit the method name.
+    """

--- a/src/compiler/syntax/expression.py
+++ b/src/compiler/syntax/expression.py
@@ -5,6 +5,8 @@ import typing
 
 import attr
 
+from . import variable
+
 
 @attr.s(frozen=True, slots=True)
 class Expression(metaclass=abc.ABCMeta):
@@ -50,6 +52,7 @@ class Variable(LValue):
         name: The name of the variable.
     """
     name: str = attr.ib()
+    annotations: typing.Sequence[variable.Variable.Annotation] = attr.ib(converter=tuple, default=(), repr=False)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/compiler/syntax/function_test.py
+++ b/src/compiler/syntax/function_test.py
@@ -125,7 +125,7 @@ class FunctionTestCase(unittest.TestCase):
     def test_init_local_scope_arguments(self):
         @attr.s(frozen=True, slots=True)
         class MyAnnotation(variable.Variable.Annotation):
-            foo: str = attr.ib()
+            my_attr: str = attr.ib()
 
         my_function = function.Function(
             arguments=[

--- a/src/compiler/syntax/namespace.py
+++ b/src/compiler/syntax/namespace.py
@@ -12,8 +12,8 @@ class Declarable(metaclass=abc.ABCMeta):
     which can be declared within a namespace.
     """
 
-    name: str = attr.ib()
-    namespace: Namespace = attr.ib()
+    name: str = attr.ib(default='')
+    namespace: typing.Optional[Namespace] = attr.ib(default=None)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/compiler/syntax/variable.py
+++ b/src/compiler/syntax/variable.py
@@ -1,3 +1,5 @@
+import typing
+
 import attr
 
 from . import namespace
@@ -10,3 +12,8 @@ class Variable(namespace.Declarable):
     NB: variable.Variable should not be confused with expression.Variable, which
     represents an expression which evaluates to the value of a variable in a scope.
     """
+    @attr.s(frozen=True, slots=True)
+    class Annotation:
+        pass
+
+    annotations: typing.Sequence[Annotation] = attr.ib(converter=tuple, default=(), repr=False)


### PR DESCRIPTION
Start defining class syntax, and add the concepts of variable annotations and function decorators.
Define the first few decorators and annotations, and document how they will be used in class definitions.
Remove the "convenience" attributes for positional/keyword/extra arguments because this would be more appropriate for the function implementation model rather than the function syntax model.
Support anonymous functions and other declarables by making namespace optional and allowing name to default to the empty string.

Class constructor semantics were inspired by the wonderful [python-attrs/attrs](https://github.com/python-attrs/attrs) library.

So far variable annotations are only implemented for function arguments and class attributes. Inline annotations will be used, but I'm not sure exactly how that will work yet.

There are also some open questions around how class constructors will work.